### PR TITLE
Fix and refactor webhook validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,25 @@ func main() {
     if err != nil {
         // Handle error
     }
-    
+	
     fmt.Printf("Invoice created: %+v\n", invoice)
+	
+    // Verify webhook
+    var body []byte
+	
+    webhook, err := client.ParseWebhook(body, true)
+    if err != nil { 
+        switch {
+        default:
+            // Handle default error
+        case errors.Is(err, cryptomus.ErrInvalidSign):
+            // Handle invalid sign error
+        case errors.Is(err, cryptomus.ErrMissingSign):
+            // Handle missing sign error
+        }
+    }
+
+    fmt.Printf("Verified webhook: %+v\n", webhook)
 }
 ```
 

--- a/cryptomus.go
+++ b/cryptomus.go
@@ -30,7 +30,7 @@ func (c *Cryptomus) fetch(method string, endpoint string, payload any) (*http.Re
 		return nil, err
 	}
 
-	sign := c.signRequest(c.paymentApiKey, body)
+	sign := signRequest(c.paymentApiKey, body)
 	req, err := http.NewRequest(method, APIURL+endpoint, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err

--- a/sign.go
+++ b/sign.go
@@ -4,32 +4,10 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
-	"errors"
 )
 
 func signRequest(apiKey string, reqBody []byte) string {
 	data := base64.StdEncoding.EncodeToString(reqBody)
 	hash := md5.Sum([]byte(data + apiKey))
 	return hex.EncodeToString(hash[:])
-}
-
-func (c *Cryptomus) VerifySign(apiKey string, reqBody []byte) error {
-	var jsonBody map[string]any
-	err := json.Unmarshal(reqBody, &jsonBody)
-	if err != nil {
-		return err
-	}
-
-	reqSign, ok := jsonBody["sign"].(string)
-	if !ok {
-		return errors.New("missing signature field in request body")
-	}
-	delete(jsonBody, "sign")
-
-	expectedSign := signRequest(apiKey, reqBody)
-	if reqSign != expectedSign {
-		return errors.New("invalid signature")
-	}
-	return nil
 }

--- a/sign.go
+++ b/sign.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 )
 
-func (c *Cryptomus) signRequest(apiKey string, reqBody []byte) string {
+func signRequest(apiKey string, reqBody []byte) string {
 	data := base64.StdEncoding.EncodeToString(reqBody)
 	hash := md5.Sum([]byte(data + apiKey))
 	return hex.EncodeToString(hash[:])
@@ -27,7 +27,7 @@ func (c *Cryptomus) VerifySign(apiKey string, reqBody []byte) error {
 	}
 	delete(jsonBody, "sign")
 
-	expectedSign := c.signRequest(apiKey, reqBody)
+	expectedSign := signRequest(apiKey, reqBody)
 	if reqSign != expectedSign {
 		return errors.New("invalid signature")
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -19,25 +19,28 @@ type WebhookConvert struct {
 }
 
 type Webhook struct {
-	Type              string         `json:"type"`
-	UUID              string         `json:"uuid"`
-	OrderId           string         `json:"order_id"`
-	Amount            string         `json:"amount"`
-	PaymentAmount     string         `json:"payment_amount"`
-	PaymentAmountUSD  string         `json:"payment_amount_usd"`
-	MerchantAmount    string         `json:"merchant_amount"`
-	Commission        string         `json:"commission"`
-	IsFinal           bool           `json:"is_final"`
-	Status            string         `json:"status"`
-	From              string         `json:"from"`
-	WalletAddressUUID string         `json:"wallet_address_uuid"`
-	Network           string         `json:"network"`
-	Currency          string         `json:"currency"`
-	PayerCurrency     string         `json:"payer_currency"`
-	AdditionalData    string         `json:"additional_data"`
-	Convert           WebhookConvert `json:"convert"`
-	TxId              string         `json:"txid"`
-	Sign              string         `json:"sign"`
+	Type                    string          `json:"type"`
+	UUID                    string          `json:"uuid"`
+	OrderId                 string          `json:"order_id"`
+	Amount                  string          `json:"amount"`
+	PaymentAmount           *string         `json:"payment_amount"`
+	PaymentAmountUSD        string          `json:"payment_amount_usd"`
+	MerchantAmount          *string         `json:"merchant_amount"`
+	Commission              *string         `json:"commission"`
+	IsFinal                 bool            `json:"is_final"`
+	Status                  string          `json:"status"`
+	From                    *string         `json:"from"`
+	WalletAddressUUID       *string         `json:"wallet_address_uuid"`
+	Network                 *string         `json:"network"`
+	Currency                string          `json:"currency"`
+	PayerCurrency           *string         `json:"payer_currency"`
+	PayerAmount             *string         `json:"payer_amount"`
+	PayerAmountExchangeRate *string         `json:"payer_amount_exchange_rate"`
+	AdditionalData          *string         `json:"additional_data"`
+	Convert                 *WebhookConvert `json:"convert,omitempty"`
+	TransferId              *string         `json:"transfer_id"`
+	TxId                    *string         `json:"txid,omitempty"`
+	Sign                    *string         `json:"sign,omitempty"`
 }
 
 type ResendWebhookRequest struct {


### PR DESCRIPTION
Thanks for this awesome lib! Currently, the webhook validation seems to be a little bit broken because of the wrong types, missing fields in the `Webhook` struct and a typo in the `(c *Cryptomus) VerifySign` function (passing unmodified `reqBody` to the sign func)

This PR:
- Makes nullable fields in the webhook struct pointers
- Adds missing undocumented webhook fields (`payer_amount`, `payer_amount_exchange_rate`, `transfer_id`)
- Moves verification logic from `(c *Cryptomus) VerifySign` to `(w *Webhook) verify` function
- Makes `signRequest` a regular function (it didn't use any values from the receiver), so it can be called from `(w *Webhook) verify`
- Escapes forward slash after marshalling modified webhook (`txid` contains a slash that has to be escaped https://doc.cryptomus.com/business/payments/webhook)
- Adds webhook verification example to the README